### PR TITLE
Convert to r7rs libraries and programs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@
 /gauche
 /guile
 /kawa
+/r7rs-libraries
+/r7rs-programs


### PR DESCRIPTION
Includes some refactoring of convert.scm.

Forget about randomness (SRFI 27) for the time being. Separate randomized tests from deterministic tests later.